### PR TITLE
docs(api): add drf-spectacular Swagger UI and OpenAPI schema endpoints

### DIFF
--- a/backend/cinema/settings.py
+++ b/backend/cinema/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'corsheaders',
     'movies',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -135,3 +136,15 @@ CORS_ALLOWED_ORIGINS = [o for o in _cors.split(",") if o.strip()]
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 5,
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",  # <— bien ici
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Movies API",
+    "DESCRIPTION": "Simple API for movies, actors and reviews (test).",
+    "VERSION": "1.0.0",
+}

--- a/backend/cinema/urls.py
+++ b/backend/cinema/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("api/", include("movies.urls")),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),            # <— JSON OpenAPI
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Django==5.0.6
 djangorestframework==3.15.2
 django-cors-headers==4.3.1
+drf-spectacular==0.27.2


### PR DESCRIPTION
## Description
Cette PR ajoute une documentation interactive de l’API via **drf-spectacular** :  
- Ajout de `drf_spectacular` dans les `INSTALLED_APPS`.  
- Configuration de `DEFAULT_SCHEMA_CLASS` dans `REST_FRAMEWORK`.  
- Définition de `SPECTACULAR_SETTINGS` (titre, description, version).  
- Ajout des endpoints :
  - `/api/schema/` → OpenAPI schema JSON
  - `/api/docs/` → Swagger UI basé sur ce schema

## Type de changement
- [x] docs (documentation)

## Checklist
- [x] Code testé localement
- [x] Tests unitaires existants passent
- [x] CI passe
- [x] Pas de secrets ou fichiers sensibles commités